### PR TITLE
Adding support for TOML configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,18 @@ For example, in order to generate the html files in a directory `./dist/html_fil
 ```
 python til-builder_main.py --output ./dist/html_files
 ```
+4. `-c` or `--config`: Allows specification of a [TOML](https://toml.io/en/) configuration file containing all required options for converted HTML files.
+
+For example: Using a TOML file containing:
+```TOML
+output = "./build"
+lang = "fr"
+```
+`python til-builder_main.py myfile.txt --config config.toml`
+
+Will set the output directory and language of the HTML files  instead of having to use `--output` and `--lang`.
+
+
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ lang = "fr"
 ```
 `python til-builder_main.py myfile.txt --config config.toml`
 
-Will set the output directory and language of the HTML files  instead of having to use `--output` and `--lang`.
+Will set the output directory and language of the HTML files  instead of having to use `--output` and `--lang`. Using `-c` or `--config` will override any other config flags provided.
 
 
 

--- a/README.md
+++ b/README.md
@@ -107,14 +107,16 @@ For example, in order to generate the html files in a directory `./dist/html_fil
 ```
 python til-builder_main.py --output ./dist/html_files
 ```
-4. `-c` or `--config`: Allows specification of a [TOML](https://toml.io/en/) configuration file containing all required options for converted HTML files.
+4. `-c` or `--config`: Allows specification of a [TOML](https://toml.io/en/) configuration file containing all required options for the program.
 
 For example: Using a TOML file containing:
 ```TOML
 output = "./build"
 lang = "fr"
 ```
-`python til-builder_main.py myfile.txt --config config.toml`
+```
+python til-builder_main.py myfile.txt --config config.toml
+```
 
 Will set the output directory and language of the HTML files  instead of having to use `--output` and `--lang`. Using `-c` or `--config` will override any other config flags provided.
 

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,2 @@
+output = "./build"
+lang = "fr"

--- a/src/utils/commandline.py
+++ b/src/utils/commandline.py
@@ -1,4 +1,5 @@
 import argparse
+import tomli
 
 # Create an ArgumentParser object
 parser = argparse.ArgumentParser(
@@ -7,6 +8,14 @@ parser = argparse.ArgumentParser(
                     )
 
 # Define arguments
+
+# Config file
+parser.add_argument(
+    '-c','--config',
+    metavar='config',
+    type=str,
+    help="Uses a provided config file to set properties of converted files"
+)
 
 # Input file or folder containing files
 parser.add_argument(
@@ -41,3 +50,17 @@ parser.add_argument(
 
 # Parse the command-line arguments
 cl_args = parser.parse_args()
+
+# Processing config file if provided
+
+if cl_args.config is not None:
+    with open(cl_args.config, 'rb') as config_file:     # Opening config file
+        try:
+            toml_vals = tomli.load(config_file)       # Loading configurations from TOML file
+        except tomli.TOMLDecodeError:
+            raise Exception("Error: Unable to decode configuration file contents")
+        except:
+            raise Exception("Error: Invalid configuration file")
+
+    for (key,value) in toml_vals.items():      
+        setattr(cl_args, key, value)       # Setting each attribute in arg namespace from tomli dictionary

--- a/src/utils/commandline.py
+++ b/src/utils/commandline.py
@@ -14,7 +14,7 @@ parser.add_argument(
     '-c','--config',
     metavar='config',
     type=str,
-    help="Uses a provided config file to set properties of converted files"
+    help="Uses a provided config file to set any valid options for the program."
 )
 
 # Input file or folder containing files


### PR DESCRIPTION
resolves #10 

I have added support for TOML files in your project using [tomli](https://github.com/hukkin/tomli) as requested in #10. Using `-c` or `--config` with a valid `.toml` config file will add any supported properties to the converted HTML.

For example: `python til-builder_main.py ../examples/ --config ../config.toml` :
Will convert any txt or md files in the examples folder to HTML with the configurations specified in the `config.toml` file:
```TOML
output = "./build"
lang = "fr"
```

If the contents of the TOML file are invalid or the file path does not exist it raises an exception and ends the program. Any attributes provided in the TOML file that are not currently supported by the program will be ignored.

I'll mark this pull request as ready to review once I finish testing and updating the README.